### PR TITLE
Add Jest tests for background script

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,3 +54,8 @@ function stopReloading() {
   chrome.storage.local.set({ countdown: 'N/A' });
   chrome.action.setBadgeText({ text: '' });
 }
+
+// Export functions for testing in Node environment
+if (typeof module !== 'undefined') {
+  module.exports = { startReloading, stopReloading };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "auto-reload-page-extension",
+  "version": "1.0.0",
+  "description": "Auto Reload Page Extension This Chrome extension allows users to automatically reload a specified tab at random intervals within a given minimum and maximum time range.",
+  "main": "background.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -1,0 +1,60 @@
+const path = require('path');
+
+describe('startReloading', () => {
+  const originalRandom = Math.random;
+  let storageData;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    storageData = { countdown: 0 };
+    global.chrome = {
+      storage: {
+        local: {
+          set: jest.fn((obj, cb) => {
+            Object.assign(storageData, obj);
+            if (cb) cb();
+          }),
+          get: jest.fn((key, cb) => {
+            if (typeof key === 'string') {
+              cb({ [key]: storageData[key] });
+            } else {
+              cb(storageData);
+            }
+          }),
+        },
+      },
+      action: {
+        setBadgeText: jest.fn(),
+        setBadgeBackgroundColor: jest.fn(),
+      },
+      tabs: {
+        reload: jest.fn((tabId, cb) => cb && cb()),
+      },
+      runtime: {
+        onMessage: { addListener: jest.fn() },
+      },
+    };
+    Math.random = jest.fn(() => 0.5);
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    Math.random = originalRandom;
+    delete global.chrome;
+  });
+
+  test('schedules timeout and updates chrome.storage', () => {
+    const { startReloading } = require(path.join('..', 'background'));
+    startReloading(1, 3, 10);
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 2000);
+    expect(global.chrome.storage.local.set).toHaveBeenCalledWith({ countdown: 2 });
+
+    // advance one second for countdown interval
+    jest.advanceTimersByTime(1000);
+    expect(global.chrome.storage.local.set).toHaveBeenLastCalledWith({ countdown: 1 });
+    expect(global.chrome.action.setBadgeText).toHaveBeenCalledWith({ text: '1' });
+  });
+});


### PR DESCRIPTION
## Summary
- add Node Jest configuration
- export background functions for testing
- setup package.json for Jest
- write tests for `startReloading`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684fe41d81648320af50ff636283a10b